### PR TITLE
Centralized DB configuration stuff!

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ After installation, the tool should be available as `ajc`, running `ajc` will em
 
 ## Configuration
 
-AJC is configured via a YAML file. Some values are hardcoded as defaults and can be omitted - currently, this is limited to an `asnake_config` key containing values for the default admin account of a local ASpace instance.
+AJC is configured via a YAML file. Some values are hardcoded as defaults and can be omitted - currently, these include:
+
+- `asnake_config` - ASnake configuration to be passed to the client
+- `postgres_config` - Configuration values to be passed directly to psycopg
+- `crosswalk_config` - Config for the Crosswalk class in this application. Currently only supports `name`, which is the name of a sqlite3 database.
 
 By default, AJC looks for a `.archivesspace_jsonmodel_converter.yml` in the user's home directory.  A different file location can be specified via the AJC_CONFIG_FILE variable, or by providing a path to the `ajc` commend via the `--config-file` option.
+
+
 
 ## Conversion of Access DB to postgresql DB
 

--- a/src/archivesspace_jsonmodel_converter/crosswalker.py
+++ b/src/archivesspace_jsonmodel_converter/crosswalker.py
@@ -1,108 +1,81 @@
 '''Supports the storage and retrieval of ID mapping between the origin system and ArchivesSpace'''
 
 import sqlite3
-from sqlite3 import Error
+from .logger import get_logger
+log = get_logger('crosswalk')
 
-ADD_NEW = 'INSERT INTO Crosswalk(orig_table, orig_id, value, aspace_id) VALUES(?, ?, ?, ?)'
-UPDATE = 'UPDATE Crosswalk SET aspace_id="{}", value="{}" WHERE orig_table="{}" AND orig_id="{}"'
-UPDATE_MATCH = "SELECT id,orig_table,orig_id, value FROM Crosswalk WHERE orig_table={} AND orig_id='{}'"
-DBNAME=""
-FETCH = 'SELECT aspace_id FROM Crosswalk WHERE orig_table="{}" AND orig_id="{}"'
-def init_dbname(name):
-    '''This will be replaced with something from the yml file'''
-    DBNAME = name
-def sql_connection():
-    try:
-        conn = sqlite3.connect(DBNAME + '.db')
-    except Error as e:
-        print(e)
-        conn.close()
-        conn = None
-    finally:
-        return conn
-   
-def crosswalk_exists():
-    conn = sql_connection()
-    cursorObj = conn.cursor()
-    retval = False
-    try:
-        bar =cursorObj.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='Crosswalk'").fetchall()
-        retval = bar != []
-    except Error as e:
-        print("unable to determine if Crosswalk exists: {}".format(e))
-    return(retval)
+UPSERT = """INSERT INTO Crosswalk(orig_table, orig_id, value, aspace_id) VALUES(?, ?, ?, ?) ON CONFLICT
+            DO UPDATE SET value = excluded.value, aspace_id = excluded.aspace_id"""
+FETCH = 'SELECT aspace_id FROM Crosswalk WHERE orig_table=? AND orig_id=?'
+class Crosswalk():
+    def __init__(self, dbname):
+        try:
+            self.conn = sqlite3.connect(f'{dbname}.db', row_factory=sqlite3.Row)
+        except sqlite3.Error as e:
+            log.error('sqlite error', error=e)
+            print(f'sqlite error: {e}')
 
-def create_crosswalk():
-    retval = False
-    try:
-        conn = sql_connection()
-        if not crosswalk_exists():
-            cursorObj = conn.cursor()
-            cursorObj.execute("CREATE TABLE Crosswalk(id integer PRIMARY KEY, orig_table text, orig_id text, value text, aspace_id text, UNIQUE(orig_table,orig_id))")
-            conn.commit()
-        else:
-            print("already exists!")
-        retval = True
-    except Error as e:
-        print("unable to create Crosswalk: {}".format(e))
-    finally:
-        conn.close()
-    return retval
+    def __del__(self):
+        self.conn.close();
 
-def add_or_update(orig_table, orig_id, value, aspace_id):
-    '''Add a crosswalk row if it doesn't already exist; otherwise update'''
-    conn = sql_connection()
-    cursorObj = conn.cursor()
-    entities = [orig_table, orig_id, value, aspace_id]
-    try:
-        cursorObj.execute(ADD_NEW,entities)
-        conn.commit()
-    except Error as e:
-        if str(e).startswith('UNIQUE constraint failed'):
-            try:
-                cursorObj.execute(UPDATE.format(aspace_id, value, orig_table, orig_id))
-                conn.commit()
-            except Error as e:
-                print("Couldn't even update: {}".format(e))
-        else:
-            print("Problem adding {}: {}".format(entities,e))
-    finally:
-        conn.close()
+    def crosswalk_exists(self):
+        cursorObj = self.conn.cursor()
+        with self.conn:
+            # returns name of table (truthy) or None
+            return cursorObj.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='Crosswalk'").fetchone()
+        # If an error happens, context manager swallows it, implicitly returns None
 
-def get_aspace_id(orig_table, orig_id):
-    ''' returns the ArchivesSpace URL corresponding the the original table/original ID mapping'''
-    conn = sql_connection()
-    cursorObj = conn.cursor()
-    aspace_id = ""
-    try:
-        cursorObj.execute(FETCH.format(orig_table, orig_id))
-        rows = cursorObj.fetchall()
-        if len(rows) > 1:
-            raise Exception("PROBLEM: MORE THAN ONE ROW!")
-        if len(rows) == 1:
-            aspace_id = rows[0][0]
-    except Error as e:
-        print(e)
-    finally:
-        conn.close()
-    return aspace_id
 
-def drop_crosswalk():
-    '''Drop the Crosswalk table all together'''
-    conn = sql_connection()
-    cursorObj = conn.cursor()
-    cursorObj.execute("DROP TABLE Crosswalk")
+    def create_crosswalk(self):
+        retval = False
+        try:
+            with self.conn:
+                if not self.crosswalk_exists():
+                    cursorObj = self.conn.cursor()
+                    cursorObj.execute("""CREATE TABLE Crosswalk(id integer PRIMARY KEY,
+                                                                orig_table text,
+                                                                orig_id text,
+                                                                value text,
+                                                                aspace_id text,
+                                                                UNIQUE(orig_table,orig_id))""")
 
-def execute_select_command(command):
-    ''' Execute an input SELECT & fetchall command '''
-    fetched = None
-    try:
-        conn = sql_connection()
+                    retval = True
+                else:
+                    print("already exists!")
+
+        except Error as e:
+            print("unable to create Crosswalk: {}".format(e))
+
+        return retval
+
+    def add_or_update(self, orig_table, orig_id, value, aspace_id):
+        '''Add a crosswalk row if it doesn't already exist; otherwise update'''
+
+        cursorObj = self.conn.cursor()
+        entities = [orig_table, orig_id, value, aspace_id]
+        try:
+            with conn:
+                cursorObj.execute(UPSERT,entities)
+
+        except Error as e:
+            print("Couldn't even update: {}".format(e))
+
+    def get_aspace_id(self, orig_table, orig_id):
+        ''' returns the ArchivesSpace URL corresponding the the original table/original ID mapping'''
+        cursorObj = self.conn.cursor()
+        aspace_id = ""
+        try:
+            with conn:
+                cursorObj.execute(FETCH, [orig_table, orig_id])
+                row = cursorObj.fetchone() # index ensures uniqueness so this is sole result or None
+                if row:
+                    return row['aspace_id']
+        except Error as e:
+            print(e)
+
+
+    def drop_crosswalk(self):
+        '''Drop the Crosswalk table all together'''
         cursorObj = conn.cursor()
-        fetched = cursorObj.execute(command).fetchall()
-    except Error as e:
-        print("Unable to execute command \"{}\": {}".format(command, e))
-    finally:
-        conn.close()
-    return fetched
-
+        with conn:
+            cursorObj.execute("DROP TABLE Crosswalk")

--- a/src/archivesspace_jsonmodel_converter/main.py
+++ b/src/archivesspace_jsonmodel_converter/main.py
@@ -22,4 +22,5 @@ def create_subjects():
     log = get_logger('main.subjects')
     log.info("Subject creation goes here")
     print("Create some subjects already!")
+    CONFIG.dynamic_configuration()
     subjects_create(CONFIG)

--- a/src/archivesspace_jsonmodel_converter/subjects.py
+++ b/src/archivesspace_jsonmodel_converter/subjects.py
@@ -1,141 +1,107 @@
 # Subjects
-from asnake.aspace import ASpace
-# Bring in the client to work at a very basic level.
-from asnake.client import ASnakeClient
 from asnake.jsonmodel import JM
-import psycopg
+
 import sys
 import re
-from configparser import ConfigParser
-from . import crosswalker as xw
 
-CONFIG = None
 # Create and authorize the client
-client = None # Asnake client, doing it this way for the nonce
 
 #need from tblLcshs and tblGeoPlaces
 pattern =  "\|([a-z])"
 
 # HARDCODED DICTIONARY for LCSH subfields
-SUBFIELD_DICT = {"a": "topical", "b": "topical", "c" : "geographic", "d": "temporal", "v": "genre_form", "x": "topical", "y": "temporal", "z": "geographic"} 
+SUBFIELD_DICT = {"a": "topical", "b": "topical", "c" : "geographic", "d": "temporal", "v": "genre_form", "x": "topical", "y": "temporal", "z": "geographic"}
 
-def postgres_params():
-	db = {}
-	for key in ("host", "dbname", "user", "password"):
-		if key in CONFIG:
-			db[key] = CONFIG[key]		
-	return db
-
-
-def clean_up(conn):
-	if conn is not None:
-		conn.close()
-		print('Database connection closed.')
-
-def get_connection():
-	conn = None
-	try:
-		# read connection parameters
-		params = postgres_params()
-		# connect to the PostgreSQL server
-		print('Connecting to the PostgreSQL database...')
-		conn = psycopg.connect(**params)
-	except (Exception, psycopg.DatabaseError) as error:
-		print(error)
-		clean_up(conn)			
-	return conn
+client = None
+xw = None
+conn = None # postgres connection
 
 def add_to_aspace(orig_id, subject):
-	''' Add a subject to ArchivesSpace'''
-	new_id = None
-	response = client.post('subjects', json=subject).json()
-	if 'status' in response and response['status'] == 'Created':
-		new_id = response['uri']	
-	elif 'error' in response:
-		err = response['error']
-		# treat a conflicting record as a win
-		if 'conflicting_record' in err:
-			new_id = err['conflicting_record'][0]
-			# print("{} Already exists as {}".format(orig_id, new_id))
-		else:
-			# look for a reason for the error
-			error = err
-			if 'source' in err:
-				error = err['source'][0]
-			print("Error detected for ID {}: {}".format(orig_id, error))
-	else:
-		print("Item {} not created for unknown reasons: {}".format(orig_id, response))	
-	return new_id
+    ''' Add a subject to ArchivesSpace'''
+    new_id = None
+    response = client.post('subjects', json=subject).json()
+    if 'status' in response and response['status'] == 'Created':
+        new_id = response['uri']
+    elif 'error' in response:
+        err = response['error']
+        # treat a conflicting record as a win
+        if 'conflicting_record' in err:
+            new_id = err['conflicting_record'][0]
+            # print("{} Already exists as {}".format(orig_id, new_id))
+        else:
+            # look for a reason for the error
+            error = err
+            if 'source' in err:
+                error = err['source'][0]
+            print("Error detected for ID {}: {}".format(orig_id, error))
+    else:
+        print("Item {} not created for unknown reasons: {}".format(orig_id, response))
+    return new_id
 
 def create_terms(subject,firstfield):
-	'''creates a list of terms in jsonmodel format'''
-	trmlist = re.split(pattern,subject)
-	trmlist.insert(0, firstfield)  # the first subfield indicator is passed through
-	term_dict  = map(lambda i: (trmlist[i], trmlist[i+1]), range(len(trmlist)-1)[::2])
-	terms = []
-	for sub,term in term_dict:
-		if term != '':
-			try:
-				entry = JM.term(vocabulary="/vocabularies/1", term_type=SUBFIELD_DICT[sub], term= term)
-				terms.append(entry)
-			except Exception as e:
-				raise e
-	return terms
+    '''creates a list of terms in jsonmodel format'''
+    trmlist = re.split(pattern,subject)
+    trmlist.insert(0, firstfield)  # the first subfield indicator is passed through
+    term_dict  = map(lambda i: (trmlist[i], trmlist[i+1]), range(len(trmlist)-1)[::2])
+    terms = []
+    for sub,term in term_dict:
+        if term != '':
+            try:
+                entry = JM.term(vocabulary="/vocabularies/1", term_type=SUBFIELD_DICT[sub], term= term)
+                terms.append(entry)
+            except Exception as e:
+                raise e
+    return terms
 
 def create_subject_json(orig_subj, firstfield):
-	terms = create_terms(orig_subj, firstfield)
-	subject = JM.subject(publish="true", source="lcsh",vocabulary="/vocabularies/1", terms=terms)
-	return subject
+    terms = create_terms(orig_subj, firstfield)
+    subject = JM.subject(publish="true", source="lcsh",vocabulary="/vocabularies/1", terms=terms)
+    return subject
 
 def process_subjects(tablename, firstfield):
-	''' Take the values and add them to ArchivesSpace '''
-	conn = get_connection()
-	if conn is None:
-		return None
-	
-	try:
-		# create a cursor
-		cur = conn.cursor()
-		cur.execute("SELECT * from {}".format(tablename))
-		while True:
-			row = cur.fetchone()
-			if row == None or len(row) < 2:
-				break
-			orig_id = row[0]
-			orig_val = row[1]
-			try:
-				subject = create_subject_json(orig_val, firstfield)
-				new_id = add_to_aspace(orig_id, subject)
-				if new_id is not None:
-					xw.add_or_update(tablename, orig_id,orig_val,new_id)
-				#TBD: what do we do with None new_ids?
-				else:
-					print("{} '{}' was not converted".format(orig_id, orig_val))
-			except Exception as e:
-				print("Exception '{}' triggered on {} '{}', which will not be converted".format(e, orig_id, orig_val))
-			finally:
-				continue
-	except Exception as e:
-		print(e)
-		print(sys.exc_info()[2])
-	finally:
-		clean_up(conn)
+    ''' Take the values and add them to ArchivesSpace '''
+    if conn is None:
+        return None
 
+    try:
+        # create a cursor
+        cur = conn.cursor()
+        cur.execute("SELECT * from {}".format(tablename))
+        while True:
+            row = cur.fetchone()
+            if row == None or len(row) < 2:
+                break
+            orig_id = row[0]
+            orig_val = row[1]
+            try:
+                subject = create_subject_json(orig_val, firstfield)
+                new_id = add_to_aspace(orig_id, subject)
+                if new_id is not None:
+                    xw.add_or_update(tablename, orig_id,orig_val,new_id)
+                #TBD: what do we do with None new_ids?
+                else:
+                    print("{} '{}' was not converted".format(orig_id, orig_val))
+            except Exception as e:
+                print("Exception '{}' triggered on {} '{}', which will not be converted".format(e, orig_id, orig_val))
+            finally:
+                continue
+    except Exception as e:
+        print(e)
+        print(sys.exc_info()[2])
 
 
 def subjects_create(config):
-	global CONFIG
-	CONFIG = config
-	global client
-	client = ASnakeClient()
-	client.authorize()	
-	xw.init_dbname(CONFIG["xwdbname"])
-	xw.create_crosswalk()
-	for table in ("tblLcshs,a", "tblGeoPlaces,c"):
-		x = table.split(',')
-		process_subjects(x[0],x[1])
-	
+    global client, xw, conn
+    client = config["d"]["asnake"].client
+    client.authorize()
+    xw = config["d"]["crosswalk"]
+    xw.create_crosswalk()
+    conn = config["d"]["postgres"]
+    for table in ("tblLcshs,a", "tblGeoPlaces,c"):
+        x = table.split(',')
+        process_subjects(x[0],x[1])
+
 # if __name__ == '__main__':
-# 	#connect()
-# 	process_lcshs('c:/Users/rlynn/aspacelinux/temp/lcshs.csv')
-# 	process_geoplaces('c:/Users/rlynn/aspacelinux/temp/geoplaces.csv')
+#     #connect()
+#     process_lcshs('c:/Users/rlynn/aspacelinux/temp/lcshs.csv')
+#     process_geoplaces('c:/Users/rlynn/aspacelinux/temp/geoplaces.csv')


### PR DESCRIPTION
Several things!
- I centralized setup of databases to configurator.py, the values should go in the yaml configuration - I put a little bit of doc up for it. 
- rewrote the subject function in main to set them up.   
- I wrapped the crosswalk stuff in a class so it could be better managed externally - it should automatically close itself when deleted/moved out of scope.
- While I was in crosswalk - rewrote some SQL, since sqlite supports ON CONFLICT upserts.

This is all pretty untested, but should work, and should be functionally identical to previous code.