### PR TITLE
Logging configuration from config file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="archivesspace_jsonmodel_converter",
-    version="0.0.1",
+    version="0.0.2",
     author="Dave and Bobbi Fox",
     author_email="pobocks@gmail.com",
     description="A tool for converting data into ArchivesSpace JSONModel objects.",

--- a/src/archivesspace_jsonmodel_converter/configurator.py
+++ b/src/archivesspace_jsonmodel_converter/configurator.py
@@ -18,6 +18,11 @@ def ConfigSources(yaml_path):
 
     # Populate asnake, postgres, and sqlite config with defaults for local devserver
     omd.update({
+        'logging_config': {
+            # filename: 'file_to_log_to.log',
+            'level': 'INFO',
+            'stream_json': True
+        },
         'asnake_config': {
             'baseurl'         : 'http://localhost:4567',
             'username'        : 'admin',

--- a/src/archivesspace_jsonmodel_converter/logger.py
+++ b/src/archivesspace_jsonmodel_converter/logger.py
@@ -43,9 +43,6 @@ def setup_logging(level=None, stream_json=True, filename=None):
     if file_handler:
         root_logger.removeHandler(file_handler)
 
-    # Default configuration is info -> stdout - the ASPACE_JSONMODEL_CONVERTER_LOG_CONFIG var can be used to override default with pre-configured values
-    from_env = os.environ.get("ASPACE_JSONMODEL_CONVERTER_LOG_CONFIG", None)
-
     level = level  or logging.INFO
     if isinstance(level, str) and level_re.match(level):
         level = getattr(logging, level.upper())

--- a/src/archivesspace_jsonmodel_converter/main.py
+++ b/src/archivesspace_jsonmodel_converter/main.py
@@ -1,5 +1,5 @@
 import click
-from .logger import get_logger
+from .logger import setup_logging, get_logger
 from .configurator import AJCConfig
 from .subjects import subjects_create
 
@@ -16,11 +16,13 @@ def config(config_file):
 @click.option('--config-file', help="Path to yaml configuration file")
 def main(config_file):
     config(config_file)
+    setup_logging(**CONFIG['logging_config'])
 
 @main.command()
 def create_subjects():
     log = get_logger('main.subjects')
     log.info("Subject creation goes here")
     print("Create some subjects already!")
+
     CONFIG.dynamic_configuration()
     subjects_create(CONFIG)


### PR DESCRIPTION
Fixed it so the logging can be configured by putting values in the `logging_config` key in the config yaml file.

Valid keys are: `
-  level`
- `filename` 
- `stream_json` 

Tested, produces a list of subjects when configured with a postgres, dbname, and asnake config!